### PR TITLE
General Refactoring of Application Class and AppModule

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-        android:name=".ApplicationClazz"
+        android:name=".GithubFollowsApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/com/skydoves/githubfollows/GithubFollowsApplication.kt
+++ b/app/src/main/java/com/skydoves/githubfollows/GithubFollowsApplication.kt
@@ -12,7 +12,7 @@ import timber.log.Timber
  * Copyright (c) 2018 skydoves rights reserved.
  */
 
-class ApplicationClazz : DaggerApplication() {
+class GithubFollowsApplication : DaggerApplication() {
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/com/skydoves/githubfollows/GithubFollowsApplication.kt
+++ b/app/src/main/java/com/skydoves/githubfollows/GithubFollowsApplication.kt
@@ -14,6 +14,10 @@ import timber.log.Timber
 
 class GithubFollowsApplication : DaggerApplication() {
 
+    private val appComponent = DaggerAppComponent.builder()
+            .application(this)
+            .build()
+
     override fun onCreate() {
         super.onCreate()
 
@@ -21,12 +25,9 @@ class GithubFollowsApplication : DaggerApplication() {
             LeakCanary.install(this)
         }
 
-        DaggerAppComponent.builder()
-                .application(this)
-                .build()
-                .inject(this)
+        appComponent.inject(this)
 
-        if(BuildConfig.DEBUG) {
+        if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
         }
 
@@ -34,6 +35,6 @@ class GithubFollowsApplication : DaggerApplication() {
     }
 
     override fun applicationInjector(): AndroidInjector<out DaggerApplication> {
-        return DaggerAppComponent.builder().application(this).build()
+        return appComponent
     }
 }

--- a/app/src/main/java/com/skydoves/githubfollows/di/AppComponent.kt
+++ b/app/src/main/java/com/skydoves/githubfollows/di/AppComponent.kt
@@ -16,10 +16,11 @@ import dagger.android.DaggerApplication
  */
 
 @Singleton
-@Component(modules = arrayOf(AndroidInjectionModule::class,
-        ActivityModule::class,
-        ViewModelModule::class,
-        AppModule::class))
+@Component(modules = [
+    (AndroidInjectionModule::class),
+    (ActivityModule::class),
+    (ViewModelModule::class),
+    (AppModule::class)])
 interface AppComponent : AndroidInjector<DaggerApplication> {
     @Component.Builder
     interface Builder {


### PR DESCRIPTION
Generally, to name Application class we should follow the convention as `AppName`+`Application`.
In AppModule we can use `[]` instead of `arrayOf`
Extract the following code to a variable to use at multiple places
```
DaggerAppComponent.builder()
           .application(this)
           .build()
```